### PR TITLE
Change apiVersion in test.yaml to match current k8s versions

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -1,7 +1,7 @@
 ## This is test deployment for Kubernetes platforms.
 ## This is not intended to be used in production.
 ##
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
**Description of the change**

`test.yaml` isn't working anymore as Deployments were removed from experimental apis in Kubernetes 1.16 (current version is 1.17). 

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

> - Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served
>
>     - Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.

**Benefits**

Compatibility with currently used stable k8s versions: 1.16+

**Possible drawbacks**

Broken compatibility with k8s before 1.9